### PR TITLE
add a select box for selecting a formula color

### DIFF
--- a/tex image link generator.py
+++ b/tex image link generator.py
@@ -32,9 +32,13 @@ size_dict = {'M': '',
 
 size_prefix = size_dict[st.selectbox('Select size', list(size_dict.keys()))]
 
+color_dict = {'black': '\color{black}',
+             'white': '\color{white}'}
+
+color_prefix = color_dict[st.selectbox('Select color', list(color_dict.keys()))]
 
 # encode
-S_quote = parse.quote_plus(size_prefix + style_prefix + S)
+S_quote = parse.quote_plus(color_prefix + size_prefix + style_prefix + S)
 
 url_prefix = 'https://render.githubusercontent.com/render/math?math='
 URL = url_prefix + S_quote


### PR DESCRIPTION
Resolve #6 in the form of allowing a formula color to be changed.

<img width="764" alt="Screen Shot 2022-03-14 at 15 13 35" src="https://user-images.githubusercontent.com/56056962/158115261-97277551-95f3-4662-9d44-07206bdf31d2.png">

This solution is based on [^1], so I believe it is also possible to change the color to something other than black and white.

[^1]: https://gist.github.com/a-rodin/fef3f543412d6e1ec5b6cf55bf197d7b?permalink_comment_id=4051474#gistcomment-4051474